### PR TITLE
fix copy/paste error in comment

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,7 +94,7 @@ title: bhf
           content: markdown
 
 - settings: # Page Settings
-  - category: # bhf can work from this point on because there is a model named Static
+  - category: # bhf can work from this point on because there is a model named Category
 
   - authors:
       table:


### PR DESCRIPTION
I'm not 100% certain of this fix - but it looks like the comment meant to say that bhf could handle the `category` details because there is a model named Category.
