### PR TITLE
Added skip blank feature.

### DIFF
--- a/Getting_Started.md
+++ b/Getting_Started.md
@@ -1,0 +1,11 @@
+### Skip blank fields on create/update
+
+You are able to skip blank fields (like password, and password_confirmation) for form settings
+on update or create action:
+
+    form:
+      display: [name, password, password_confirmation]
+      skip_blank: [password, password_confirmation]
+
+The feature can be useful when user admin wish not to change a password of a user record, but
+the user model validates that password must be not null.

--- a/app/controllers/bhf/entries_controller.rb
+++ b/app/controllers/bhf/entries_controller.rb
@@ -1,5 +1,7 @@
 class Bhf::EntriesController < Bhf::ApplicationController
   before_filter :load_platform, :load_model, :set_page, :set_quick_edit
+  before_filter :params_permit_default, except: [:update, :create]
+  before_filter :params_permit, only: [:update, :create]
   before_filter :load_object, except: [:create, :new, :sort]
   before_filter :load_new_object, only: [:create, :new]
 
@@ -130,7 +132,25 @@ class Bhf::EntriesController < Bhf::ApplicationController
 
     def load_model
       @model = @platform.model
-      @permited_params = ActionController::Parameters.new(params[@platform.model_name.to_sym]).permit!
+    end
+
+    def params_permit_default
+      parms = params[@platform.model_name.to_sym]
+      @permited_params = ActionController::Parameters.new(parms).permit!
+    end
+
+    def params_permit
+      skip_blank = @settings.find_platform_settings(params['platform']).
+        hash['form']['skip_blank']
+      parms =
+      if skip_blank
+        params[@platform.model_name.to_sym].select do |key, value|
+          !skip_blank.include?(key) || !value.blank?
+        end
+      else
+        params[@platform.model_name.to_sym]
+      end
+      @permited_params = ActionController::Parameters.new(parms).permit!
     end
 
     def load_object


### PR DESCRIPTION
### Skip blank fields on create/update

You are able to skip blank fields (like password, and password_confirmation) for form settings
on update or create action:

    form:
      display: [name, password, password_confirmation]
      skip_blank: [password, password_confirmation]

The feature can be useful when user admin wish not to change a password of a user record, but
the user model validates that password must be not null.
